### PR TITLE
WSL2 Ubuntu のために tmux の設定を変更した

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -43,5 +43,5 @@ unbind -T copy-mode-vi Enter
 if-shell "uname | grep 'Darwin'" \
   'bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"'
 if-shell "uname -r | grep 'microsoft'" \
-  'bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "win32yank.exe -i"'
+  'bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "clip.exe"'
 

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -26,14 +26,22 @@ bind r source-file ~/.tmux.conf
 #set-option -g status-right "#(~/src/tmux-powerline/powerline.sh right)"
 # set-option -g status-utf8 on # this is old?
 
-set-option -g default-command "which reattach-to-user-namespace > /dev/null && reattach-to-user-namespace -l /usr/local/bin/zsh || /usr/local/bin/zsh"
+# Use macOS clipboard
+if-shell "uname | grep 'Darwin'" \
+  'set-option -g default-command "which reattach-to-user-namespace > /dev/null && reattach-to-user-namespace -l /usr/local/bin/zsh || /usr/local/bin/zsh"'
 
 # Setup 'v' to begin selection as in Vim
 bind-key -T copy-mode-vi v send-keys -X begin-selection
-bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
+if-shell "uname | grep 'Darwin'" \
+  'bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"'
+if-shell "uname -r | grep 'microsoft'" \
+  'bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "clip.exe"'
+
 
 # Update default binding of `Enter` to also use copy-pipe
 unbind -T copy-mode-vi Enter
-bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-nd-cancel "reattach-to-user-namespace pbcopy"
-
+if-shell "uname | grep 'Darwin'" \
+  'bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"'
+if-shell "uname -r | grep 'microsoft'" \
+  'bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "win32yank.exe -i"'
 

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -6,8 +6,9 @@ unbind-key C-b
 # ESC キーの効きを良くする
 set -s escape-time 0
 
-# shell を /usr/local/bin/zsh にしておく
-set-option -g default-shell "/usr/local/bin/zsh"
+# shell を zsh にしておく
+if-shell "[ -x /usr/local/bin/zsh ]" 'set-option -g default-shell "/usr/local/bin/zsh"'
+if-shell "[ -x /usr/bin/zsh ]" 'set-option -g default-shell "/usr/bin/zsh"'
 
 # コピーモードは vi キーバインド
 set-window-option -g mode-keys vi


### PR DESCRIPTION
- Ubuntu だと /usr/bin/zsh が apt で更新されるのでそっちを見るようにした
- WSL2 でも clipboard を windows 側に持っていけるようにした
  - windows → WSL2 は対応してない
  ~~- 対応するにあたり win32yank.exe を Windows で最初から PATH が通ってるところに放り込んだ~~
    ~~- USERPROFILE とかにした方が良さそう……~~
  - win32yank は「vcruntime140.dllが見つかりません」ということで動かなかったので削除した