### PR TITLE
補完設定やキーバインドの設定ファイル読み込みを修正

### DIFF
--- a/.fzf.zsh
+++ b/.fzf.zsh
@@ -6,8 +6,19 @@ fi
 
 # Auto-completion
 # ---------------
-[[ $- == *i* ]] && source "/home/mugijiru/.fzf/shell/completion.zsh" 2> /dev/null
+if [[ $- == *i* ]]; then
+  if [ -e "/home/mugijiru/.fzf/shell/completion.zsh" ]; then
+    source "/home/mugijiru/.fzf/shell/completion.zsh"
+  elif [ -e "/usr/share/fzf/completion.zsh" ]; then
+    source "/usr/share/fzf/completion.zsh"
+  fi
+fi
 
 # Key bindings
 # ------------
-source "/home/mugijiru/.fzf/shell/key-bindings.zsh"
+if [ -e "/home/mugijiru/.fzf/shell/key-bindings.zsh" ]; then
+  source "/home/mugijiru/.fzf/shell/key-bindings.zsh"
+elif [ -e "/usr/share/fzf/key-bindings.zsh" ]; then
+  source "/usr/share/fzf/key-bindings.zsh"
+fi
+


### PR DESCRIPTION
環境によってファイルの存在位置が変わるので
WSL(Ubuntu) 用の設定と Manjaro 用の設定を
if で切り分けるようにした

/usr/share に入ってるのが Manjaro 用の設定。

実は Ubuntu もそこから読めばいいのかもしれないが
ちょっと確認が取れてないので今回はそこは対応しない。