### PR TITLE
email を変更し editor 設定を追加した

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -11,4 +11,6 @@
 
 [user]
 	name = mugijiru
-	email = kirinbiiru+pg@gmail.com
+	email = 106833+mugijiru@users.noreply.github.com
+[core]
+	editor = vim


### PR DESCRIPTION
email は GitHub で使ってる秘匿用のメアドを通常利用するようにした

editor は Vim を使うのでそちらを指定。
デフォルトだと nano が動いてしまい困っていた