### PR TITLE
X 起動時の設定を Manjaro 向けに変更した

### DIFF
--- a/.xinitrc
+++ b/.xinitrc
@@ -1,14 +1,66 @@
 #!/bin/bash
-# $Xorg: xinitrc.cpp,v 1.3 2000/08/17 19:54:30 cpqbld Exp $
-
-# /etc/X11/xinit/xinitrc
 #
-# global xinitrc file, used by all X sessions started by xinit (startx)
+# ~/.xinitrc
+#
+# Executed by startx (run your window manager from here)
 
-# invoke global X session script
-feh --bg-scale /usr/share/backgrounds/konata.jpg
-xcompmgr -n &
-. /etc/X11/Xsession
+userresources=$HOME/.Xresources
+usermodmap=$HOME/.Xmodmap
+sysresources=/etc/X11/xinit/.Xresources
+sysmodmap=/etc/X11/xinit/.Xmodmap
 
-xmodmap ~/.Xmodmap
+SESSION=${1:-xfce-session}
 
+# merge in defaults and keymaps
+
+if [ -f $sysresources ]; then
+    xrdb -merge $sysresources
+fi
+
+if [ -f $sysmodmap ]; then
+    xmodmap $sysmodmap
+fi
+
+if [ -f "$userresources" ]; then
+    xrdb -merge "$userresources"
+fi
+
+if [ -f "$usermodmap" ]; then
+    xmodmap "$usermodmap"
+fi
+
+# start some nice programs
+
+if [ -d /etc/X11/xinit/xinitrc.d ] ; then
+    for f in /etc/X11/xinit/xinitrc.d/?*.sh ; do
+        [ -x "$f" ] && . "$f"
+    done
+    unset f
+fi
+
+get_session(){
+	local dbus_args=(--sh-syntax --exit-with-session)
+	case "$1" in
+		awesome) dbus_args+=(awesome) ;;
+		bspwm) dbus_args+=(bspwm-session) ;;
+		budgie) dbus_args+=(budgie-desktop) ;;
+		cinnamon) dbus_args+=(cinnamon-session) ;;
+		deepin) dbus_args+=(startdde) ;;
+		enlightenment) dbus_args+=(enlightenment_start) ;;
+		fluxbox) dbus_args+=(startfluxbox) ;;
+		gnome) dbus_args+=(gnome-session) ;;
+		i3|i3wm) dbus_args+=(i3 --shmlog-size 0) ;;
+		jwm) dbus_args+=(jwm) ;;
+		kde) dbus_args+=(startplasma-x11) ;;
+		lxde) dbus_args+=(startlxde) ;;
+		lxqt) dbus_args+=(lxqt-session) ;;
+		mate) dbus_args+=(mate-session) ;;
+		xfce) dbus_args+=(xfce4-session) ;;
+		openbox) dbus_args+=(openbox-session) ;;
+		*) dbus_args+=("$1") ;;
+	esac
+
+	echo "dbus-launch ${dbus_args[*]}"
+}
+
+exec $(get_session "$1")

--- a/.xprofile
+++ b/.xprofile
@@ -1,1 +1,14 @@
-feh --bg-scale /usr/share/backgrounds/konata.jpg
+export DefaultIMModule=fcitx
+export GTK_IM_MODULE=fcitx
+export QT_IM_MODULE=fcitx
+export XMODIFIERS="@im=fcitx"
+
+# Disable Capslock
+setxkbmap -option "ctrl:nocaps"
+
+# Set Key Repeat
+xset r rate 200 25
+
+# Set Display Resolution and Position
+xrandr --output eDP-1 --mode 2880x1620 --right-of DP-2
+


### PR DESCRIPTION
.xprofile は12年前に追加していたが
その時の環境は既に存在していないので
Manjaro 向けの設定で上書きした。

前半の export 部分では
日本語入力で fcitx を使うための設定を入れている。

後半の各コマンドの実行部分では
あまり使わない CapsLock を無効にしたり、
キーのリピート設定を
押しっぱなしで 200msec 経過したら 25hz でリピートしたり
解像度を少し目に優しい感じにした上で
外部ディスプレイの右側にノートのディスプレイを配置するようにしてる
家でのディスプレイ配置である

また .xinitrc も同じく12年前に追加しているが
これも当時の環境はないので Manjaro の設定で上書きしている。

ただ Manjaro + i3wm 環境でこれが使われてる気配はない。
まあ元ファイルよりマシそうぐらいの感覚で上書きしている。
本当に使われてないのかは別途確認した方が良さそう