### PR TITLE
systemd で起動している ssh-agent を zsh から使えるようにした

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -153,3 +153,8 @@ if [ `uname` = "Darwin" ]; then
 fi
 
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
+
+# use ssh agent with systemd
+if [ -e "$XDG_RUNTIME_DIR/ssh-agent.socket" ]; then
+  export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-agent.socket"
+fi


### PR DESCRIPTION
systemd を使って
sudo systemctl --user ssh-agent enable
で ssh-agent をログイン時に有効にしている。

そしてその socket は XDG_RUNTIME_DIR にあるので
そこを参照できるように SSH_AUTH_SOCK を設定している

systemd で動かしてない場合はそうやって参照はできないので
ソケットファイルの存在チェックを一応挟んでいる