### PR TITLE
i3status の設定ファイルを用意し表示を調整した

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -13,7 +13,7 @@ set $mod Mod4
 
 # Font for window titles. Will also be used by the bar unless a different font
 # is used in the bar {} block below.
-font pango:monospace 16
+font pango:monospace, Icons, Font Awesome 5 Free, 20
 
 # This font is widely installed, provides lots of unicode glyphs, right-to-left
 # text rendering and scalability on retina/hidpi displays (thanks to pango).

--- a/.config/i3status/config
+++ b/.config/i3status/config
@@ -1,0 +1,53 @@
+# i3status configuration file.
+# see "man i3status" for documentation.
+
+# It is important that this file is edited as UTF-8.
+# The following line should contain a sharp s:
+# ß
+# If the above line is not correctly displayed, fix your editor first!
+
+general {
+        colors = true
+        interval = 5
+}
+
+order += "ipv6"
+order += "wireless _first_"
+order += "ethernet _first_"
+order += "battery all"
+order += "disk /"
+order += "load"
+order += "memory"
+order += "tztime local"
+
+wireless _first_ {
+        format_up = "W: (%quality at %essid) %ip"
+        format_down = "W: down"
+}
+
+ethernet _first_ {
+        format_up = "E: %ip (%speed)"
+        format_down = "E: down"
+}
+
+battery all {
+        format = "%status %percentage %remaining"
+}
+
+disk "/" {
+        format = "%avail"
+}
+
+load {
+        format = "%1min"
+}
+
+memory {
+        format = "%used | %available"
+        threshold_degraded = "1G"
+        format_degraded = "MEMORY < %available"
+}
+
+tztime local {
+        format = "%Y-%m-%d %H:%M:%S"
+}

--- a/.config/i3status/config
+++ b/.config/i3status/config
@@ -11,9 +11,9 @@ general {
         interval = 5
 }
 
-order += "ipv6"
+# order += "ipv6"
 order += "wireless _first_"
-order += "ethernet _first_"
+# order += "ethernet _first_"
 order += "battery all"
 order += "disk /"
 order += "load"

--- a/.config/i3status/config
+++ b/.config/i3status/config
@@ -11,43 +11,34 @@ general {
         interval = 5
 }
 
-# order += "ipv6"
-order += "wireless _first_"
-# order += "ethernet _first_"
 order += "battery all"
 order += "disk /"
 order += "load"
 order += "memory"
 order += "tztime local"
 
-wireless _first_ {
-        format_up = "W: (%quality at %essid) %ip"
-        format_down = "W: down"
-}
-
-ethernet _first_ {
-        format_up = "E: %ip (%speed)"
-        format_down = "E: down"
-}
-
 battery all {
         format = "%status %percentage %remaining"
+	status_chr = ""
+	status_bat = ""
+	status_unk = ""
+	status_full = ""
 }
 
 disk "/" {
-        format = "%avail"
+        format = " %avail"
 }
 
 load {
-        format = "%1min"
+        format = "%1min"
 }
 
 memory {
-        format = "%used | %available"
+        format = " %used | %available"
         threshold_degraded = "1G"
         format_degraded = "MEMORY < %available"
 }
 
 tztime local {
-        format = "%Y-%m-%d %H:%M:%S"
+        format = "%m/%d %H:%M"
 }


### PR DESCRIPTION
/etc/i3status.conf からコピーしてきて突っ込んできてカスタマイズした

カスタマイズは、絵文字が使えるようにして
何の表示なのかは絵文字で表現することにして
長過ぎる表示は短かくなるようにし、
WiFi 表示は tray 側にも同様のがあったので削除した。

とりあえずこのリポジトリを clone してきたら

kmdir -p ~/.config/i3status
ln -s path/to/dotfiles/.config/i3status/config ~/.config/i3status/config

とすることでそれが使えるようになる。

なお 絵文字は ttf-font-icons, ttf-font-awesome に依存しているので

```
$ sudo pacman -S ttf-font-awesome
$ sudo pacman -S ttf-font-icons
```

する必要あり