### PR TITLE
manjaro & tmux で yank する時には xsel を使うようにした

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -36,6 +36,8 @@ if-shell "uname | grep 'Darwin'" \
   'bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"'
 if-shell "uname -r | grep 'microsoft'" \
   'bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "clip.exe"'
+if-shell "uname -r | grep 'MANJARO'" \
+  'bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "xsel --input --clipboard"'
 
 
 # Update default binding of `Enter` to also use copy-pipe


### PR DESCRIPTION
Mac, WSL 用の設定はあったが
Linux 用の設定はなかった
uname -r したら MANJARO という文字列が含まれていたので
それで判定して xsel を使うようにした

コマンドの有無で判定してもいい気もするけど
ひとまずこれでいいかなという気がしている