### PR TITLE
i3bars に i3-blocks + i3blocks-contrib を使うようにした

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -178,7 +178,7 @@ bindsym $mod+r mode "resize"
 # Start i3bar to display a workspace bar (plus the system information i3status
 # finds out, if available)
 bar {
-        status_command i3status
+        status_command i3blocks
 }
 
 exec_always --no-startup-id autotiling

--- a/.config/i3/config
+++ b/.config/i3/config
@@ -31,11 +31,17 @@ exec --no-startup-id xss-lock --transfer-sleep-lock -- i3lock --nofork
 exec --no-startup-id nm-applet
 
 # Use pactl to adjust volume in PulseAudio.
-set $refresh_i3status killall -SIGUSR1 i3status
-bindsym XF86AudioRaiseVolume exec --no-startup-id pactl set-sink-volume @DEFAULT_SINK@ +10% && $refresh_i3status
-bindsym XF86AudioLowerVolume exec --no-startup-id pactl set-sink-volume @DEFAULT_SINK@ -10% && $refresh_i3status
-bindsym XF86AudioMute exec --no-startup-id pactl set-sink-mute @DEFAULT_SINK@ toggle && $refresh_i3status
-bindsym XF86AudioMicMute exec --no-startup-id pactl set-source-mute @DEFAULT_SOURCE@ toggle && $refresh_i3status
+# set $refresh_i3status killall -SIGUSR1 i3status
+# bindsym XF86AudioRaiseVolume exec --no-startup-id pactl set-sink-volume @DEFAULT_SINK@ +10% && $refresh_i3status
+# bindsym XF86AudioLowerVolume exec --no-startup-id pactl set-sink-volume @DEFAULT_SINK@ -10% && $refresh_i3status
+# bindsym XF86AudioMute exec --no-startup-id pactl set-sink-mute @DEFAULT_SINK@ toggle && $refresh_i3status
+# bindsym XF86AudioMicMute exec --no-startup-id pactl set-source-mute @DEFAULT_SOURCE@ toggle && $refresh_i3status
+
+# change volume or toggle mute
+bindsym XF86AudioRaiseVolume exec amixer -q -D pulse sset Master 5%+ && pkill -RTMIN+10 i3blocks 
+bindsym XF86AudioLowerVolume exec amixer -q -D pulse sset Master 5%- && pkill -RTMIN+10 i3blocks
+bindsym XF86AudioMute exec amixer -q -D pulse sset Master toggle && pkill -RTMIN+10 i3blocks
+
 
 # Use Mouse+$mod to drag floating windows to their wanted position
 floating_modifier $mod

--- a/.config/i3blocks/config
+++ b/.config/i3blocks/config
@@ -1,0 +1,162 @@
+# i3blocks config file
+#
+# Please see man i3blocks for a complete reference!
+# The man page is also hosted at http://vivien.github.io/i3blocks
+#
+# List of valid properties:
+#
+# align
+# color
+# command
+# full_text
+# instance
+# interval
+# label
+# min_width
+# name
+# separator
+# separator_block_width
+# short_text
+# signal
+# urgent
+
+# Global properties
+#
+# The top properties below are applied to every block, but can be overridden.
+# Each block command defaults to the script name to avoid boilerplate.
+# Change $SCRIPT_DIR to the location of your scripts!
+command=~/.config/i3blocks/i3blocks-contrib/$BLOCK_NAME/$BLOCK_NAME
+separator_block_width=15
+markup=none
+
+
+[github]
+interval=60
+format=json
+markup=pango
+
+# Volume indicator
+#
+# The first parameter sets the step (and units to display)
+# The second parameter overrides the mixer selection
+# See the script for details.
+
+
+[volume]
+label= 
+interval=once
+signal=10
+
+[arch-update]
+markup=pango
+interval= 3600
+QUIET=true
+# WATCH=^linux.* ^pacman.*
+BASE_COLOR=#5fff5f
+UPDATE_COLOR=#FFFF85
+# AUR=true
+LABEL= eparator=false
+
+
+#STEP=5%
+
+# Memory usage
+#
+# The type defaults to "mem" if the instance is not specified.
+[memory2]
+label= 
+interval=persist
+markup=pango
+bar_chars=_▁▂▃▄▅▆▇█
+
+# bar_size=20
+# critical=50
+# warning=20
+
+# [memory]
+# label=SWAP
+# instance=swap
+# separator=false
+# interval=30
+
+# Disk usage
+#
+# The directory defaults to $HOME if the instance is not specified.
+# The script may be called with a optional argument to set the alert
+# (defaults to 10 for 10%).
+[disk]
+label= 
+#DIR=/mnt/data
+interval=30
+
+# CPU usage
+#
+# The script may be called with -w and -c switches to specify thresholds,
+# see the script for details.
+[cpu_usage]
+label= 
+interval=10
+
+[load_average]
+label= 
+interval=10
+
+# Battery indicator
+#
+# The battery instance defaults to 0.
+[battery2]
+markup=pango
+#label=⚡
+interval=30
+
+
+# Date Time
+#
+[time]
+label= 
+command=date '+%m/%d %H:%M'
+interval=5
+
+# Generic media player support
+#
+# This displays "ARTIST - SONG" if a music is playing.
+# Supported players are: spotify, vlc, audacious, xmms2, mplayer, and others.
+# Set to %any to automatically pick (Requires playerctl >=2.1.1)
+#[mediaplayer]
+# This picks any player, with vlc as first, and spotify as last choice
+#instance=vlc,%any,spotify
+#interval=5
+#signal=10
+
+# OpenVPN support
+#
+# Support multiple VPN, with colors.
+#[openvpn]
+#interval=20
+
+# Temperature
+#
+# Support multiple chips, though lm-sensors.
+# The script may be called with -w and -c switches to specify thresholds,
+# see the script for details.
+#[temperature]
+#label=TEMP
+#interval=10
+
+# Key indicators
+#
+# Add the following bindings to i3 config file:
+#
+# bindsym --release Caps_Lock exec pkill -SIGRTMIN+11 i3blocks
+# bindsym --release Num_Lock  exec pkill -SIGRTMIN+11 i3blocks
+#[keyindicator]
+#KEY=CAPS
+#markup=pango
+#interval=once
+#signal=11
+
+#[keyindicator]
+#KEY=NUM
+#markup=pango
+#interval=once
+#signal=11

--- a/.gitconfig
+++ b/.gitconfig
@@ -14,3 +14,6 @@
 	email = 106833+mugijiru@users.noreply.github.com
 [core]
 	editor = vim
+[credential "https://github.com"]
+	helper = 
+	helper = !/usr/bin/gh auth git-credential

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".config/i3blocks/i3blocks-contrib"]
+	path = .config/i3blocks/i3blocks-contrib
+	url = https://github.com/vivien/i3blocks-contrib.git


### PR DESCRIPTION
i3status だと表示が寂しいので
i3blocks を使うと良い感じになるかな〜と期待してそっちに切り替えることにした

i3status の設定も消してはいないので
必要とあれば戻せる状態ではある。

## 表示内容

ひとまず今回は

- GitHub 通知数
- checkupdates で更新があれば表示
- メモリ使用量
- ストレージ残容量
- CPU 使用率
- ロードアベレージ
- バッテリー状況(充電ステータスとか残量とか)
- 現在日時

に対応している。
他も表示に便利そうなのがあれば対応したい。

## 気に入ってないところ

- 音量調整がここからはできない
- メモリ表示部が大きい
  - 視覚的なのはいいけど具体的な数字は mouseover とかで十分なのになあ
- バッテリー駆動の時のアイコン表示がなぜかヘッドホン
  - 入れてるフォントのせいと思われる