### PR TITLE
Gitub のユーザー名を指定するようにした

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -17,3 +17,5 @@
 [credential "https://github.com"]
 	helper = 
 	helper = !/usr/bin/gh auth git-credential
+[github]
+	user = mugijiru


### PR DESCRIPTION
会社用と個人用でアカウントを分けてたのもあって
元々は指定してなかったものの
指定しておいた方が良さそうなので指定することにした