### PR TITLE
キー配置をカスタマイズした

### DIFF
--- a/.xprofile
+++ b/.xprofile
@@ -3,12 +3,17 @@ export GTK_IM_MODULE=fcitx
 export QT_IM_MODULE=fcitx
 export XMODIFIERS="@im=fcitx"
 
+# Set Display Resolution and Position
+xrandr --output eDP-1 --mode 2880x1620 --right-of DP-2
+
+#####################
+  Keyboard Settings
+#####################
+
 # Disable Capslock
 setxkbmap -option "ctrl:nocaps"
 
 # Set Key Repeat
 xset r rate 200 25
 
-# Set Display Resolution and Position
-xrandr --output eDP-1 --mode 2880x1620 --right-of DP-2
 

--- a/.xprofile
+++ b/.xprofile
@@ -16,4 +16,10 @@ setxkbmap -option "ctrl:nocaps"
 # Set Key Repeat
 xset r rate 200 25
 
+# for MD650L(チルダの位置が Esc になってるので調整)
 
+## ESC as grave and asciitilde(Esc をチルダとして扱う)
+xmodmap -e 'keycode 9 = grave asciitilde grave asciitilde'
+
+## Ctrl Left as Esc(左 Ctrl を Esc として扱う)
+xmodmap -e 'keycode 37 = Escape NoSymbol Escape'


### PR DESCRIPTION
MD650L では通常のキーボードと配置が異なっていて
チルダなどのキーがいなくなってるが、それだと不便なので以下のように置き換えている。

- Esc を チルダ/バッククォートに変更
- 左 Ctrl を Esc に変更

普通のキーボードならチルダ/バッククォートがある位置が
MD650L だと Esc になっていて
チルダなどのよく使うキーが使えなくなってしまってるので
普通のキーボードと同様に使えるようにした。

それに伴い Esc がいなくなってしまうので
左 Ctrl を Esc として使うように変更した。
なお Capslock を Ctrl としてあり、
従来の左 Ctrl は使ってないので弊害はない