### PR TITLE
ログイン後のディスプレイの調整は autorandr を使うようにした

### DIFF
--- a/.xprofile
+++ b/.xprofile
@@ -4,7 +4,13 @@ export QT_IM_MODULE=fcitx
 export XMODIFIERS="@im=fcitx"
 
 # Set Display Resolution and Position
-xrandr --output eDP-1 --mode 2880x1620 --right-of DP-2
+# if xrandr | grep "DP-2 disconnected"; then
+#     xrandr --output eDP-1 --mode 1920x1080 --output DP-2 --off
+# else
+#     xrandr --output eDP-1 --mode 2880x1620 --right-of DP-2
+# fi
+autorandr --change
+
 
 #####################
   Keyboard Settings

--- a/.xprofile
+++ b/.xprofile
@@ -13,7 +13,7 @@ autorandr --change
 
 
 #####################
-  Keyboard Settings
+#  Keyboard Settings
 #####################
 
 # Disable Capslock

--- a/.xprofile
+++ b/.xprofile
@@ -9,8 +9,11 @@ export XMODIFIERS="@im=fcitx"
 # else
 #     xrandr --output eDP-1 --mode 1920x1080 --right-of DP-2
 # fi
-autorandr --change
 
+# autorandr がある時のみディスプレイの自動検出・設定を実行する
+if [ -x "$(command -v autorandr)" ]; then
+   autorandr --change
+fi
 
 #####################
 #  Keyboard Settings

--- a/.xprofile
+++ b/.xprofile
@@ -5,9 +5,9 @@ export XMODIFIERS="@im=fcitx"
 
 # Set Display Resolution and Position
 # if xrandr | grep "DP-2 disconnected"; then
-#     xrandr --output eDP-1 --mode 1920x1080 --output DP-2 --off
+#     xrandr --output eDP-1 --mode 2880x1620 --output DP-2 --off
 # else
-#     xrandr --output eDP-1 --mode 2880x1620 --right-of DP-2
+#     xrandr --output eDP-1 --mode 1920x1080 --right-of DP-2
 # fi
 autorandr --change
 


### PR DESCRIPTION
autorandr でディスプレイに繋いでる時の設定と
そうでない時の設定を切り替えできそうなので
それを使うようにした

また、一旦はコメントで、
autorandr を使わずに xrandr だけで対応するコードも残している。

あと autorandr の設定をどこかに残しておきたいけど
マシン固有になりそうなのでここに Commit するのは躊躇している