### PR TITLE
i3bar 表示位置を上に移動した

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -38,7 +38,7 @@ exec --no-startup-id nm-applet
 # bindsym XF86AudioMicMute exec --no-startup-id pactl set-source-mute @DEFAULT_SOURCE@ toggle && $refresh_i3status
 
 # change volume or toggle mute
-bindsym XF86AudioRaiseVolume exec amixer -q -D pulse sset Master 5%+ && pkill -RTMIN+10 i3blocks 
+bindsym XF86AudioRaiseVolume exec amixer -q -D pulse sset Master 5%+ && pkill -RTMIN+10 i3blocks
 bindsym XF86AudioLowerVolume exec amixer -q -D pulse sset Master 5%- && pkill -RTMIN+10 i3blocks
 bindsym XF86AudioMute exec amixer -q -D pulse sset Master toggle && pkill -RTMIN+10 i3blocks
 
@@ -184,6 +184,7 @@ bindsym $mod+r mode "resize"
 # Start i3bar to display a workspace bar (plus the system information i3status
 # finds out, if available)
 bar {
+        position top
         status_command i3blocks
         separator_symbol 
 	colors {


### PR DESCRIPTION
視線移動的に上側の方が良さそうな感じがしたので
デフォルトでは下側に表示される i3bar を
上側に移動した

上側が好みなのはこの間まで Mac を使っていたからかもしれないが
とりあえずしばらくこれで運用してみる