### PR TITLE
Fcitx5 から IBus に乗り換えた

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -193,6 +193,6 @@ bar {
 }
 
 exec_always --no-startup-id autotiling
-exec --no-startup-id fcitx5
+# exec --no-startup-id fcitx5
+exec --no-startup-id ibus-daemon -drx
 exec --no-startup-id /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1 &
-

--- a/.xprofile
+++ b/.xprofile
@@ -1,7 +1,11 @@
-export DefaultIMModule=fcitx
-export GTK_IM_MODULE=fcitx
-export QT_IM_MODULE=fcitx
-export XMODIFIERS="@im=fcitx"
+# export DefaultIMModule=fcitx
+# export GTK_IM_MODULE=fcitx
+# export QT_IM_MODULE=fcitx
+# export XMODIFIERS="@im=fcitx"
+export DefaultIMModule=ibus
+export GTK_IM_MODULE=ibus
+export QT_IM_MODULE=ibus
+export XMODIFIERS="@im=ibus"
 
 # Set Display Resolution and Position
 # if xrandr | grep "DP-2 disconnected"; then


### PR DESCRIPTION
Fcitx5 では Chromium 系のアプリ(Vivaldi, Slack)で
打鍵が反映されないという挙動をしていたので
IBus に乗り換えた