### PR TITLE
Workspace を外部ディスプレイに移動するコマンドを追加した

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -147,6 +147,9 @@ bindsym $mod+Shift+8 move container to workspace number $ws8
 bindsym $mod+Shift+9 move container to workspace number $ws9
 bindsym $mod+Shift+0 move container to workspace number $ws10
 
+# Moving workspaces between screens
+bindsym $mod+p move workspace to output left
+
 # reload the configuration file
 bindsym $mod+Shift+c reload
 # restart i3 inplace (preserves your layout/session, can be used to upgrade i3)


### PR DESCRIPTION
PC 起動後にディスプレイ接続すると
ノート側のディスプレイに全てのワークスペースが配置され
外部ディスプレイ側には空のワークスペースが表示される。

外部ディスプレイを正面に置いてメインで使っている
接続後にはワークスペースごとそちらに移動させた方が便利。
というわけでひとまず移動できるコマンドを用意した

できれば接続時に自動でそっちにワークスペースが移動された方が良いが
ひとまずは接続後にコマンドを叩く方向で逃げる。

また、逆方向で
ノート PC のディスプレイに移動するのも入れた方が良さそうだけど
それも今回は対応しない