### PR TITLE
rofi でクリップボード管理ができるようにした

### DIFF
--- a/.config/greenclip.toml
+++ b/.config/greenclip.toml
@@ -1,0 +1,11 @@
+
+[greenclip]
+  blacklisted_applications = []
+  enable_image_support = true
+  history_file = "/home/mugijiru/.cache/greenclip.history"
+  image_cache_directory = "/tmp/greenclip"
+  max_history_length = 50
+  max_selection_size_bytes = 0
+  static_history = ["Greenclip has been updated to v4.1, update your new config file at ~/.config/greenclip.toml"]
+  trim_space_from_selection = true
+  use_primary_selection_as_input = false

--- a/.config/i3/config
+++ b/.config/i3/config
@@ -59,6 +59,7 @@ bindsym $mod+d exec --no-startup-id rofi -modi drun -show drun
 # There also is i3-dmenu-desktop which only displays applications shipping a
 # .desktop file. It is a wrapper around dmenu, so you need that installed.
 # bindcode $mod+40 exec --no-startup-id i3-dmenu-desktop
+bindsym $mod+c exec --no-startup-id rofi -modi "clipboard:greenclip print" -show clipboard
 
 # change focus
 bindsym $mod+h focus left


### PR DESCRIPTION
rofi に対応しているクリップボードマネージャである
https://github.com/erebe/greenclip を導入して設定しました。

AUR で提供されているので
`yay -S rofi-greenclip` で入れています。

greenclip 自体の設定ファイルは特に弄ってないですが
同時にコミットしています