### PR TITLE
Emacs の更新のあるパッケージ数を出すコマンドを置き換えた

### DIFF
--- a/.config/i3blocks/config
+++ b/.config/i3blocks/config
@@ -48,9 +48,9 @@ interval=once
 signal=10
 
 [emacs-update]
-command=emacs --batch -Q -l ~/.emacs.d//el-get-lock-update-check.el --eval='(el-get-lock-update-check-execute t)' 2> /dev/null
+command=~/.emacs.d/count-emacs-obsolute-packages.sh 2> /dev/null
 label=Emacs:
-interval=1800
+interval=300
 
 [arch-update]
 markup=pango


### PR DESCRIPTION
https://github.com/mugijiru/.emacs.d/pull/958
でこれに使えるスクリプトを作ったのでそれに置き換えた。

更新チェック内容を cache するようにしたので
チェック回数を増やすことができるし、
cache をクリアすることで
最新の状態が早く反映されるようになったつもり