### PR TITLE
Add gtk-3.0 config

### DIFF
--- a/.config/gtk-3.0/bookmarks
+++ b/.config/gtk-3.0/bookmarks
@@ -1,0 +1,5 @@
+file:///home/mugijiru/Documents
+file:///home/mugijiru/Music
+file:///home/mugijiru/Pictures
+file:///home/mugijiru/Videos
+file:///home/mugijiru/Downloads

--- a/.config/gtk-3.0/settings.ini
+++ b/.config/gtk-3.0/settings.ini
@@ -1,0 +1,2 @@
+[Settings]
+gtk-key-theme-name = Emacs

--- a/.config/i3/config
+++ b/.config/i3/config
@@ -192,7 +192,7 @@ bar {
         status_command i3blocks
         separator_symbol 
 	colors {
- 	  separator #ffff00
+	  separator #ffff00
 	}
 }
 


### PR DESCRIPTION
- bookmarks を追加
  - これはユーザー名も入るから入れなくて良かったかもしれない
  - `~/` とか使えると良いけど `file:///` 形式だから無理だろうなあ……
- settings.ini を用意し `gtk-key-theme-name = Emacs` を設定
  - こっちが本命。Emacs キーバインドで生きたい
  - 動いている環境ですぐに使いたい場合は `$ gsettings set org.gnome.desktop.interface gtk-key-theme "Emacs"` を実行すれば良いみたい