### PR TITLE
feat: Improve lock screen setting

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -162,6 +162,10 @@ bindsym $mod+Shift+r restart
 # exit i3 (logs you out of your X session)
 bindsym $mod+Shift+e exec "i3-nagbar -t warning -m 'You pressed the exit shortcut. Do you really want to exit i3? This will end your X session.' -B 'Yes, exit i3' 'i3-msg exit'"
 
+# lock screen
+set $Locker i3lock --nofork -t -i /usr/share/backgrounds/wallpapers-juhraya/Manjaro\ Juhraya\ -\ dark_2.png && sleep 1
+bindsym $mod+m exec --no-startup-id $Locker
+
 # resize window (you can also use the mouse for that)
 mode "resize" {
         # These bindings trigger as soon as you enter the resize mode

--- a/.config/i3/config
+++ b/.config/i3/config
@@ -24,7 +24,7 @@ font pango:monospace, Icons, Font Awesome 5 Free, 20
 
 # xss-lock grabs a logind suspend inhibit lock and will use i3lock to lock the
 # screen before suspend. Use loginctl lock-session to lock your screen.
-exec --no-startup-id xss-lock --transfer-sleep-lock -- i3lock --nofork
+exec --no-startup-id xss-lock --transfer-sleep-lock -- i3lock --nofork -t -i /usr/share/backgrounds/wallpapers-juhraya/Manjaro\ Juhraya\ -\ dark_2.png
 
 # NetworkManager is the most popular way to manage wireless networks on Linux,
 # and nm-applet is a desktop environment-independent system tray GUI for it.


### PR DESCRIPTION
# 概要

ロック画面に関する i3wm の設定を変更した

# 変更内容詳細

## `$mod+m` による即時ロック

これまで即時ロックには対応してなかったけどやっぱりロックできた方がいいよねってことで
ロックできるようにした

なおその際、適当にカッコ良さげな画像を背景に表示させる設定も入れている

## 指定時間が経過した後の自動ロック画面の背景画像を指定

上の即時ロックの時と同じ画像を指定している。
これまでは真っ白画面で味気なかったのだ