### PR TITLE
feat: 画面の明るさ調整ができるようにした & i3block で明るさを示すようにした

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -42,6 +42,10 @@ bindsym XF86AudioRaiseVolume exec amixer -q -D pulse sset Master 5%+ && pkill -R
 bindsym XF86AudioLowerVolume exec amixer -q -D pulse sset Master 5%- && pkill -RTMIN+10 i3blocks
 bindsym XF86AudioMute exec amixer -q -D pulse sset Master toggle && pkill -RTMIN+10 i3blocks
 
+# Screen brightness controls
+bindsym XF86MonBrightnessUp exec xbacklight -inc 10 && pkill -RTMIN+5 i3blocks # increase screen brightness
+bindsym XF86MonBrightnessDown exec xbacklight -dec 10 && pkill -RTMIN+5 i3blocks # decrease screen brightness
+
 # Wallpaper
 exec --no-startup-id ~/.fehbg
 

--- a/.config/i3blocks/config
+++ b/.config/i3blocks/config
@@ -35,12 +35,17 @@ interval=60
 format=json
 markup=pango
 
+# Backlight indicator
+[backlight]
+label=☀ 
+interval=once
+signal=5
+
 # Volume indicator
 #
 # The first parameter sets the step (and units to display)
 # The second parameter overrides the mixer selection
 # See the script for details.
-
 
 [volume]
 label= 


### PR DESCRIPTION
# 概要

キーボードからノート PC 本体の画面の明るさを調整できるようにした上で
i3block でその明るさを表示するようにした

# 課題

これまではノート PC の画面の明るさを調整できずにいた。
そのため、今どのような明るさかを表示する必要もなかった。

# 対応内容

## キーボードからの明るさ調整

Fn キーを押しながら F5/F6 にそれぞれ割り当てられた明るさ調整のボタンで
画面の明るさを変更できるようにした。

これまでうまく動かせていなかったが

```
sudo gpasswd -a <USERNAME> video
```

で自身を video グループに入れて再起動することで明るさの調整ができるようになった :tada:

## i3block で明るさを表示

明るさを表示することで明る過ぎることがわかりやすくなるかなって思って表示するようにした

# その他

まあ、明るさを弄れなくてもあまり困っていなかったけど、弄れる方が暗いところでは暗くできて良いよね